### PR TITLE
Better timeout thread names

### DIFF
--- a/src/main/java/org/junit/internal/runners/statements/FailOnTimeout.java
+++ b/src/main/java/org/junit/internal/runners/statements/FailOnTimeout.java
@@ -19,21 +19,24 @@ public class FailOnTimeout extends Statement {
     private final TimeUnit timeUnit;
     private final long timeout;
     private final boolean lookForStuckThread;
+    private String testName;
     private volatile ThreadGroup threadGroup = null;
 
-    public FailOnTimeout(Statement originalStatement, long millis) {
-        this(originalStatement, millis, TimeUnit.MILLISECONDS);
+    public FailOnTimeout(Statement originalStatement, long millis, String testName) {
+        this(originalStatement, millis, TimeUnit.MILLISECONDS, testName);
     }
 
-    public FailOnTimeout(Statement originalStatement, long timeout, TimeUnit unit) {
-        this(originalStatement, timeout, unit, false);
+    public FailOnTimeout(Statement originalStatement, long timeout, TimeUnit unit, String testName) {
+        this(originalStatement, timeout, unit, false, testName);
     }
 
-    public FailOnTimeout(Statement originalStatement, long timeout, TimeUnit unit, boolean lookForStuckThread) {
+    public FailOnTimeout(Statement originalStatement, long timeout, TimeUnit unit, boolean lookForStuckThread,
+                         String testName) {
         this.originalStatement = originalStatement;
         this.timeout = timeout;
         timeUnit = unit;
         this.lookForStuckThread = lookForStuckThread;
+        this.testName = testName;
     }
 
     @Override
@@ -41,7 +44,7 @@ public class FailOnTimeout extends Statement {
         CallableStatement callable = new CallableStatement();
         FutureTask<Throwable> task = new FutureTask<Throwable>(callable);
         threadGroup = new ThreadGroup("FailOnTimeoutGroup");
-        Thread thread = new Thread(threadGroup, task, "Time-limited test");
+        Thread thread = new Thread(threadGroup, task, testName);
         thread.setDaemon(true);
         thread.start();
         callable.awaitStarted();

--- a/src/main/java/org/junit/rules/Timeout.java
+++ b/src/main/java/org/junit/rules/Timeout.java
@@ -1,10 +1,10 @@
 package org.junit.rules;
 
+import java.util.concurrent.TimeUnit;
+
 import org.junit.internal.runners.statements.FailOnTimeout;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
-
-import java.util.concurrent.TimeUnit;
 
 /**
  * The Timeout Rule applies the same timeout to all test methods in a class:
@@ -118,6 +118,6 @@ public class Timeout implements TestRule {
     }
 
     public Statement apply(Statement base, Description description) {
-        return new FailOnTimeout(base, timeout, timeUnit, lookForStuckThread);
+        return new FailOnTimeout(base, timeout, timeUnit, lookForStuckThread, description.getDisplayName());
     }
 }

--- a/src/main/java/org/junit/runners/BlockJUnit4ClassRunner.java
+++ b/src/main/java/org/junit/runners/BlockJUnit4ClassRunner.java
@@ -270,7 +270,7 @@ public class BlockJUnit4ClassRunner extends ParentRunner<FrameworkMethod> {
 
         Statement statement = methodInvoker(method, test);
         statement = possiblyExpectingExceptions(method, test, statement);
-        statement = withPotentialTimeout(method, test, statement);
+        statement = withPotentialTimeout(method, statement);
         statement = withBefores(method, test, statement);
         statement = withAfters(method, test, statement);
         statement = withRules(method, test, statement);
@@ -307,10 +307,9 @@ public class BlockJUnit4ClassRunner extends ParentRunner<FrameworkMethod> {
      * takes more than the specified number of milliseconds.
      */
     @Deprecated
-    protected Statement withPotentialTimeout(FrameworkMethod method,
-            Object test, Statement next) {
+    protected Statement withPotentialTimeout(FrameworkMethod method, Statement next) {
         long timeout = getTimeout(method.getAnnotation(Test.class));
-        return timeout > 0 ? new FailOnTimeout(next, timeout) : next;
+        return timeout > 0 ? new FailOnTimeout(next, timeout,method.getClass() + method.getName()) : next;
     }
 
     /**

--- a/src/test/java/org/junit/tests/internal/runners/statements/FailOnTimeoutTest.java
+++ b/src/test/java/org/junit/tests/internal/runners/statements/FailOnTimeoutTest.java
@@ -12,7 +12,6 @@ import static org.junit.Assert.fail;
 
 import java.util.concurrent.TimeUnit;
 
-import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.internal.runners.statements.FailOnTimeout;
@@ -32,8 +31,7 @@ public class FailOnTimeoutTest {
 
     private final TestStatement statement = new TestStatement();
 
-    private final FailOnTimeout failOnTimeout = new FailOnTimeout(statement,
-            TIMEOUT);
+    private final FailOnTimeout failOnTimeout = new FailOnTimeout(statement,TIMEOUT, "Test Name");
 
     @Test
     public void throwsTestTimedOutException() throws Throwable {
@@ -115,7 +113,7 @@ public class FailOnTimeoutTest {
     public void stopEndlessStatement() throws Throwable {
         InfiniteLoopStatement infiniteLoop = new InfiniteLoopStatement();
         FailOnTimeout infiniteLoopTimeout = new FailOnTimeout(infiniteLoop,
-                TIMEOUT);
+                TIMEOUT,"TestName");
         try {
             infiniteLoopTimeout.evaluate();
         } catch (Exception timeoutException) {
@@ -142,7 +140,7 @@ public class FailOnTimeoutTest {
     @Test
     public void stackTraceContainsRealCauseOfTimeout() throws Throwable {
         StuckStatement stuck = new StuckStatement();
-        FailOnTimeout stuckTimeout = new FailOnTimeout(stuck, TIMEOUT);
+        FailOnTimeout stuckTimeout = new FailOnTimeout(stuck, TIMEOUT, "TestName");
         try {
             stuckTimeout.evaluate();
             // We must not get here, we expect a timeout exception
@@ -166,6 +164,20 @@ public class FailOnTimeoutTest {
             assertFalse(
                     "Stack trace contains other than the real cause of the timeout, which can be very misleading",
                     stackTraceContainsOtherThanTheRealCauseOfTheTimeout);
+        }
+    }
+
+    @Test
+    public void timeoutThreadNameTest() throws Throwable {
+        Statement stuck = new InfiniteLoopStatement();
+        FailOnTimeout stuckTimeout = new FailOnTimeout(stuck, TIMEOUT, "TestName");
+        try {
+            stuckTimeout.evaluate();
+            // We must not get here, we expect a timeout exception
+            fail("Expected timeout exception");
+        } catch (Exception timeoutException) {
+            timeoutException.printStackTrace();
+            StackTraceElement[] stackTrace = timeoutException.getStackTrace();
         }
     }
 


### PR DESCRIPTION
Pull request related to #799, this is a try to have more meaningful names on the timeout test threads.

