### PR TITLE
Strict verification of resource deletion in TemporaryFolder rule

### DIFF
--- a/src/main/java/org/junit/rules/TemporaryFolder.java
+++ b/src/main/java/org/junit/rules/TemporaryFolder.java
@@ -10,8 +10,8 @@ import org.junit.Rule;
 /**
  * The TemporaryFolder Rule allows creation of files and folders that should
  * be deleted when the test method finishes (whether it passes or
- * fails). Whether the deletion is successful or not is not checked by this rule.
- * No exception will be thrown in case the deletion fails.
+ * fails).
+ * By default no exception will be thrown in case the deletion fails.
  *
  * <p>Example of usage:
  * <pre>
@@ -26,6 +26,17 @@ import org.junit.Rule;
  *      // ...
  *     }
  * }
+ * </pre>
+ * 
+ * <p>
+ * TemporaryFolder rule supports assured deletion mode, which
+ * will fail the test in case deletion fails with {@link AssertionError}.
+ * 
+ * <p>
+ * Creating TemporaryFolder with assured deletion:
+ * <pre>
+ *  &#064;Rule
+ *  public TemporaryFolder folder= TemporaryFolder.builder().assureDeletion().build();
  * </pre>
  *
  * @since 4.7

--- a/src/main/java/org/junit/rules/TemporaryFolder.java
+++ b/src/main/java/org/junit/rules/TemporaryFolder.java
@@ -1,5 +1,7 @@
 package org.junit.rules;
 
+import static org.junit.Assert.fail;
+
 import java.io.File;
 import java.io.IOException;
 
@@ -30,16 +32,92 @@ import org.junit.Rule;
  */
 public class TemporaryFolder extends ExternalResource {
     private final File parentFolder;
+    private final boolean assureDeletion;
     private File folder;
-
+    
+    /**
+     * Create a temporary folder which uses system default temporary-file 
+     * directory to create temporary resources.
+     */
     public TemporaryFolder() {
-        this(null);
+        this((File) null);
     }
 
+    /**
+     * Create a temporary folder which uses the specified directory to create 
+     * temporary resources.
+     * 
+     * @param parentFolder folder where temporary resources will be created. 
+     * If {@code null} then system default temporary-file directory is used. 
+     * 
+     */
     public TemporaryFolder(File parentFolder) {
         this.parentFolder = parentFolder;
+        this.assureDeletion = false;
     }
 
+    /**
+     * Create a {@link TemporaryFolder} initialized with
+     * values from a builder.
+     */
+    protected TemporaryFolder(Builder builder) {
+        this.parentFolder = builder.parentFolder;
+        this.assureDeletion = builder.assureDeletion;
+    }
+    
+    /**
+     * Returns a new builder for building an instance of {@link TemporaryFolder}.
+     * 
+     * @since 4.13
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builds an instance of {@link TemporaryFolder}.
+     * 
+     * @since 4.13
+     */
+    public static class Builder {
+        
+        private File parentFolder;
+        private boolean assureDeletion;
+
+        protected Builder() {}
+        
+        /**
+         * Specifies which folder to use for creating temporary resources. 
+         * If {@code null} then system default temporary-file directory is
+         * used.
+         * 
+         * @return this
+         */
+        public Builder parentFolder(File parentFolder) {
+            this.parentFolder = parentFolder;
+            return this;
+        }
+        
+        /**
+         * Setting this flag assures that no resources are left undeleted. Failure 
+         * to fulfill the assurance results in failure of tests with an 
+         * {@link IllegalStateException}.
+         * 
+         * @return this
+         */
+        public Builder assureDeletion() {
+            this.assureDeletion = true;
+            return this;
+        }
+        
+        /**
+         * Builds a {@link TemporaryFolder} instance using the values in this builder.
+         */
+        public TemporaryFolder build() {
+            return new TemporaryFolder(this);
+        }
+    }
+    
     @Override
     protected void before() throws Throwable {
         create();
@@ -150,21 +228,45 @@ public class TemporaryFolder extends ExternalResource {
 
     /**
      * Delete all files and folders under the temporary folder. Usually not
-     * called directly, since it is automatically applied by the {@link Rule}
+     * called directly, since it is automatically applied by the {@link Rule}.
+     * 
+     * <p>
+     * Throws {@link IllegalStateException} if unable to clean up resources
+     * and deletion of resources is assured.
+     * 
+     * @throws IllegalStateException if unable to clean up resources and 
+     * deletion of resources is assured.
      */
     public void delete() {
-        if (folder != null) {
-            recursiveDelete(folder);
+        if (!tryDelete()) {
+            if (assureDeletion) {
+                fail("Unable to clean up temporary folder " + folder);
+            }
         }
     }
 
-    private void recursiveDelete(File file) {
+    /**
+     * Tries to delete all files and folders under the temporary folder and
+     * returns whether deletion was successful or not.
+     * 
+     * @return true if all resources are deleted successfully, false otherwise.
+     */
+    protected boolean tryDelete() {
+        if (folder == null) {
+            return true;
+        }
+        
+        return recursiveDelete(folder);
+    }
+    
+    private boolean recursiveDelete(File file) {
+        boolean result = true;
         File[] files = file.listFiles();
         if (files != null) {
             for (File each : files) {
-                recursiveDelete(each);
+                result = result && recursiveDelete(each);
             }
         }
-        file.delete();
+        return result && file.delete();
     }
 }

--- a/src/main/java/org/junit/rules/Timeout.java
+++ b/src/main/java/org/junit/rules/Timeout.java
@@ -84,7 +84,7 @@ public class Timeout implements TestRule {
     }
 
     /**
-     * Create a {@code Timeout} instance initialized with values form
+     * Create a {@code Timeout} instance initialized with values from
      * a builder.
      *
      * @since 4.12

--- a/src/test/java/org/junit/tests/AllTests.java
+++ b/src/test/java/org/junit/tests/AllTests.java
@@ -55,6 +55,7 @@ import org.junit.tests.experimental.rules.NameRulesTest;
 import org.junit.tests.experimental.rules.RuleChainTest;
 import org.junit.tests.experimental.rules.RuleMemberValidatorTest;
 import org.junit.tests.experimental.rules.TempFolderRuleTest;
+import org.junit.tests.experimental.rules.TemporaryFolderRuleAssuredDeletionTest;
 import org.junit.tests.experimental.rules.TemporaryFolderUsageTest;
 import org.junit.tests.experimental.rules.TestRuleTest;
 import org.junit.tests.experimental.rules.TestWatcherTest;
@@ -231,7 +232,8 @@ import org.junit.validator.PublicClassValidatorTest;
         CategoryValidatorTest.class,
         ForwardCompatibilityPrintingTest.class,
         DescriptionTest.class,
-        ErrorReportingRunnerTest.class
+        ErrorReportingRunnerTest.class,
+        TemporaryFolderRuleAssuredDeletionTest.class
 })
 public class AllTests {
     public static Test suite() {

--- a/src/test/java/org/junit/tests/experimental/rules/TemporaryFolderRuleAssuredDeletionTest.java
+++ b/src/test/java/org/junit/tests/experimental/rules/TemporaryFolderRuleAssuredDeletionTest.java
@@ -1,5 +1,6 @@
 package org.junit.tests.experimental.rules;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.junit.Assert.assertThat;
 import static org.junit.experimental.results.PrintableResult.testResult;
 import static org.junit.experimental.results.ResultMatchers.failureCountIs;
@@ -7,7 +8,6 @@ import static org.junit.experimental.results.ResultMatchers.isSuccessful;
 
 import java.io.IOException;
 
-import org.hamcrest.CoreMatchers;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.results.PrintableResult;
@@ -57,7 +57,7 @@ public class TemporaryFolderRuleAssuredDeletionTest {
     public void testStrictVerificationFailure() {
         PrintableResult result = testResult(HasTempFolderWithAssuredDeletion.class);
         assertThat(result, failureCountIs(1));
-        assertThat(result.toString(), CoreMatchers.containsString("Unable to clean up temporary folder"));
+        assertThat(result.toString(), containsString("Unable to clean up temporary folder"));
     }
     
     public static class HasTempFolderWithoutAssuredDeletion {

--- a/src/test/java/org/junit/tests/experimental/rules/TemporaryFolderRuleAssuredDeletionTest.java
+++ b/src/test/java/org/junit/tests/experimental/rules/TemporaryFolderRuleAssuredDeletionTest.java
@@ -1,0 +1,77 @@
+package org.junit.tests.experimental.rules;
+
+import static org.junit.Assert.assertThat;
+import static org.junit.experimental.results.PrintableResult.testResult;
+import static org.junit.experimental.results.ResultMatchers.failureCountIs;
+import static org.junit.experimental.results.ResultMatchers.isSuccessful;
+
+import java.io.IOException;
+
+import org.hamcrest.CoreMatchers;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.results.PrintableResult;
+import org.junit.rules.TemporaryFolder;
+
+public class TemporaryFolderRuleAssuredDeletionTest {
+    
+    public static class TemporaryFolderStub extends TemporaryFolder {
+        public TemporaryFolderStub(BuilderStub builder) {
+            super(builder);
+        }
+
+        /*
+         * Don't need to create as we are overriding deletion
+         */
+        @Override
+        public void create() throws IOException {
+            
+        }
+        
+        /*
+         * Simulates failure to clean-up temporary folder
+         */
+        @Override
+        protected boolean tryDelete() {
+            return false;
+        }
+    }
+    
+    public static class BuilderStub extends TemporaryFolder.Builder {
+        @Override
+        public TemporaryFolder build() {
+            return new TemporaryFolderStub(this);
+        }
+    }
+    
+    public static class HasTempFolderWithAssuredDeletion {
+        @Rule public TemporaryFolder folder = new BuilderStub().assureDeletion().build();
+        
+        @Test
+        public void test() {
+            // no-op
+        }
+    }
+    
+    @Test
+    public void testStrictVerificationFailure() {
+        PrintableResult result = testResult(HasTempFolderWithAssuredDeletion.class);
+        assertThat(result, failureCountIs(1));
+        assertThat(result.toString(), CoreMatchers.containsString("Unable to clean up temporary folder"));
+    }
+    
+    public static class HasTempFolderWithoutAssuredDeletion {
+        @Rule public TemporaryFolder folder = new BuilderStub().build();
+        
+        @Test
+        public void test() {
+               // no-op
+        }
+    }
+    
+    @Test
+    public void testStrictVerificationSuccess() {
+        PrintableResult result = testResult(HasTempFolderWithoutAssuredDeletion.class);
+        assertThat(result, isSuccessful());
+    }
+}


### PR DESCRIPTION
PR that adds support of strict verification of deleted resources when using `TemporaryFolder` rule #1001