### PR TITLE
Remove deprecated JUnitSystem.exit() method

### DIFF
--- a/src/main/java/org/junit/internal/JUnitSystem.java
+++ b/src/main/java/org/junit/internal/JUnitSystem.java
@@ -4,11 +4,6 @@ import java.io.PrintStream;
 
 public interface JUnitSystem {
 
-    /**
-     * Will be removed in the next major release
-     */
-    @Deprecated
-    void exit(int code);
-
     PrintStream out();
+
 }

--- a/src/main/java/org/junit/internal/RealSystem.java
+++ b/src/main/java/org/junit/internal/RealSystem.java
@@ -4,14 +4,6 @@ import java.io.PrintStream;
 
 public class RealSystem implements JUnitSystem {
 
-    /**
-     * Will be removed in the next major release
-     */
-    @Deprecated
-    public void exit(int code) {
-        System.exit(code);
-    }
-
     public PrintStream out() {
         return System.out;
     }

--- a/src/test/java/org/junit/tests/TestSystem.java
+++ b/src/test/java/org/junit/tests/TestSystem.java
@@ -7,21 +7,13 @@ import java.io.PrintStream;
 import org.junit.internal.JUnitSystem;
 
 public class TestSystem implements JUnitSystem {
+
     private PrintStream out;
-    public int fCode;
-    private ByteArrayOutputStream fOutContents;
+    private ByteArrayOutputStream outContents;
 
     public TestSystem() {
-        fOutContents = new ByteArrayOutputStream();
-        out = new PrintStream(fOutContents);
-    }
-
-    /**
-     * Will be removed in the next major release
-     */
-    @Deprecated
-    public void exit(int code) {
-        fCode = code;
+        outContents = new ByteArrayOutputStream();
+        out = new PrintStream(outContents);
     }
 
     public PrintStream out() {
@@ -29,7 +21,7 @@ public class TestSystem implements JUnitSystem {
     }
 
     public OutputStream outContents() {
-        return fOutContents;
+        return outContents;
     }
 
 }


### PR DESCRIPTION
Do we need to wait two years to remove this?