### PR TITLE
Fix for #803: improve error message for assertArrayEquals() when multi-dimensional arrays have different lengths

### DIFF
--- a/src/main/java/org/junit/internal/ComparisonCriteria.java
+++ b/src/main/java/org/junit/internal/ComparisonCriteria.java
@@ -39,8 +39,9 @@ public abstract class ComparisonCriteria {
         }
         String header = message == null ? "" : message + ": ";
 
-        int expectedsLength = assertArraysAreSameLength(expecteds,
-                actuals, outer ? header : "");
+        // Only include the user-provided message in the outer exception.
+        String exceptionMessage = outer ? header : "";
+        int expectedsLength = assertArraysAreSameLength(expecteds, actuals, exceptionMessage);
 
         for (int i = 0; i < expectedsLength; i++) {
             Object expected = Array.get(expecteds, i);
@@ -53,6 +54,7 @@ public abstract class ComparisonCriteria {
                     e.addDimension(i);
                     throw e;
                 } catch (AssertionError e) {
+                    // Array lengths differed.
                     throw new ArrayComparisonFailure(header, e, i);
                 }
             } else {

--- a/src/main/java/org/junit/internal/ComparisonCriteria.java
+++ b/src/main/java/org/junit/internal/ComparisonCriteria.java
@@ -25,6 +25,11 @@ public abstract class ComparisonCriteria {
      */
     public void arrayEquals(String message, Object expecteds, Object actuals)
             throws ArrayComparisonFailure {
+        arrayEquals(message, expecteds, actuals, true);
+    }
+
+    private void arrayEquals(String message, Object expecteds, Object actuals, boolean outer)
+            throws ArrayComparisonFailure {
         if (expecteds == actuals
             || Arrays.deepEquals(new Object[] {expecteds}, new Object[] {actuals})) {
             // The reflection-based loop below is potentially very slow, especially for primitive
@@ -35,7 +40,7 @@ public abstract class ComparisonCriteria {
         String header = message == null ? "" : message + ": ";
 
         int expectedsLength = assertArraysAreSameLength(expecteds,
-                actuals, header);
+                actuals, outer ? header : "");
 
         for (int i = 0; i < expectedsLength; i++) {
             Object expected = Array.get(expecteds, i);
@@ -43,10 +48,12 @@ public abstract class ComparisonCriteria {
 
             if (isArray(expected) && isArray(actual)) {
                 try {
-                    arrayEquals(message, expected, actual);
+                    arrayEquals(message, expected, actual, false);
                 } catch (ArrayComparisonFailure e) {
                     e.addDimension(i);
                     throw e;
+                } catch (AssertionError e) {
+                    throw new ArrayComparisonFailure(header, e, i);
                 }
             } else {
                 try {

--- a/src/test/java/org/junit/tests/assertion/AssertionTest.java
+++ b/src/test/java/org/junit/tests/assertion/AssertionTest.java
@@ -212,6 +212,26 @@ public class AssertionTest {
     }
 
     @Test
+    public void multiDimensionalArraysDifferentLengthMessage() {
+        try {
+            assertArrayEquals("message", new Object[][]{{true, true}, {false, false}}, new Object[][]{{true, true}, {false}});
+            fail();
+        } catch (AssertionError exception) {
+            assertEquals("message: arrays first differed at element [1]; array lengths differed, expected.length=2 actual.length=1", exception.getMessage());
+        }
+    }
+
+    @Test
+    public void multiDimensionalArraysDifferentLengthNoMessage() {
+        try {
+            assertArrayEquals(new Object[][]{{true, true}, {false, false}}, new Object[][]{{true, true}, {false}});
+            fail();
+        } catch (AssertionError exception) {
+            assertEquals("arrays first differed at element [1]; array lengths differed, expected.length=2 actual.length=1", exception.getMessage());
+        }
+    }
+
+    @Test
     public void arraysWithNullElementEqual() {
         Object[] objects1 = new Object[]{null};
         Object[] objects2 = new Object[]{null};

--- a/src/test/java/org/junit/tests/assertion/AssertionTest.java
+++ b/src/test/java/org/junit/tests/assertion/AssertionTest.java
@@ -215,20 +215,24 @@ public class AssertionTest {
     public void multiDimensionalArraysDifferentLengthMessage() {
         try {
             assertArrayEquals("message", new Object[][]{{true, true}, {false, false}}, new Object[][]{{true, true}, {false}});
-            fail();
         } catch (AssertionError exception) {
             assertEquals("message: arrays first differed at element [1]; array lengths differed, expected.length=2 actual.length=1", exception.getMessage());
+            return;
         }
+
+        fail("Expected AssertionError to be thrown");
     }
 
     @Test
     public void multiDimensionalArraysDifferentLengthNoMessage() {
         try {
             assertArrayEquals(new Object[][]{{true, true}, {false, false}}, new Object[][]{{true, true}, {false}});
-            fail();
         } catch (AssertionError exception) {
             assertEquals("arrays first differed at element [1]; array lengths differed, expected.length=2 actual.length=1", exception.getMessage());
+            return;
         }
+
+        fail("Expected AssertionError to be thrown");
     }
 
     @Test


### PR DESCRIPTION
This is an implementation of the suggestion made in #803. Please note that the two new unit tests may make obsolete part of (but certainly not all of) PR #804.