### PR TITLE
A new method to expect a thrown exception

### DIFF
--- a/src/main/java/org/junit/Assert.java
+++ b/src/main/java/org/junit/Assert.java
@@ -991,14 +991,16 @@ public class Assert {
      * @return the expected exception, if it is thrown
      * @throws Exception any exception <i>other</i> than the expected exception
      */
-    public static <T extends Exception> T expect(Class<T> exceptionClass, ExceptionSupplier<T> supplier) throws Exception {
+    public static <T extends Throwable> T expect(Class<T> exceptionClass, ExceptionSupplier<T> supplier) throws Exception {
         try {
             supplier.get();
-        } catch (Exception e) {
-            if (exceptionClass.isInstance(e)) {
-                return exceptionClass.cast(e);
+        } catch (Throwable t) {
+            if (exceptionClass.isInstance(t)) {
+                return exceptionClass.cast(t);
             }
-            throw e;
+            AssertionError error = new AssertionError("Expected a " + exceptionClass.getName() + " to be thrown, but caught a " + t.getClass().getName() + " instead");
+            error.initCause(t);
+            throw error;
         }
         throw new AssertionError("Expected a " + exceptionClass.getName() + " to be thrown");
     }

--- a/src/main/java/org/junit/Assert.java
+++ b/src/main/java/org/junit/Assert.java
@@ -955,4 +955,51 @@ public class Assert {
             Matcher<? super T> matcher) {
         MatcherAssert.assertThat(reason, actual, matcher);
     }
+
+    /**
+     * Executes a code block, expecting an exception to be thrown.
+     *
+     * If the expected exception is thrown, it is caught and returned.
+     * If an exception is not thrown, an AssertionError will be thrown.
+     * If an unexpected exception is thrown, it will not be caught.
+     *
+     * This is a Java 8 convenience method that encapsulates this pattern:
+     *
+     * <pre>
+     *     try {
+     *         doSomething();
+     *         fail("expected an Exception")
+     *     } catch (Exception e) {
+     *         //assert something about the exception
+     *     }
+     * </pre>
+     *
+     * and replaces it with:
+     *
+     * <pre>
+     *     Exception e = expect(Exception.class, () -&gt; doSomething());
+     *     ///assert something about the exception
+     * </pre>
+     *
+     * This is sometimes preferable to using <pre>@Test(expected=...)</pre>, because
+     * the exact line that should throw the exception is obvious, and you can make
+     * assertions about the encountered exception (has a certain cause or a certain message, etc).
+     *
+     * @param exceptionClass the expected exception class
+     * @param supplier a lambda expression (or anonymous interface implementation) that is expected to throw an Exception
+     * @param <T> The expected type of exception
+     * @return the expected exception, if it is thrown
+     * @throws Exception any exception <i>other</i> than the expected exception
+     */
+    public static <T extends Exception> T expect(Class<T> exceptionClass, ExceptionSupplier<T> supplier) throws Exception {
+        try {
+            supplier.get();
+        } catch (Exception e) {
+            if (exceptionClass.isInstance(e)) {
+                return exceptionClass.cast(e);
+            }
+            throw e;
+        }
+        throw new AssertionError("Expected a " + exceptionClass.getName() + " to be thrown");
+    }
 }

--- a/src/main/java/org/junit/ExceptionSupplier.java
+++ b/src/main/java/org/junit/ExceptionSupplier.java
@@ -1,0 +1,13 @@
+package org.junit;
+
+/**
+ * A functional interface used to call code that is expected to throw an exception
+ * @param <T> The type of exception expected to be thrown by {@link ExceptionSupplier#get()}
+ */
+public interface ExceptionSupplier<T extends Exception> {
+    /**
+     * Execute code that is expected to throw an exception
+     * @throws T the type of exception expected to be thrown
+     */
+    void get() throws T, Exception;
+}

--- a/src/main/java/org/junit/ExceptionSupplier.java
+++ b/src/main/java/org/junit/ExceptionSupplier.java
@@ -4,7 +4,7 @@ package org.junit;
  * A functional interface used to call code that is expected to throw an exception
  * @param <T> The type of exception expected to be thrown by {@link ExceptionSupplier#get()}
  */
-public interface ExceptionSupplier<T extends Exception> {
+public interface ExceptionSupplier<T extends Throwable> {
     /**
      * Execute code that is expected to throw an exception
      * @throws T the type of exception expected to be thrown

--- a/src/test/java/org/junit/tests/assertion/AssertionTest.java
+++ b/src/test/java/org/junit/tests/assertion/AssertionTest.java
@@ -694,8 +694,56 @@ public class AssertionTest {
                 }
             });
             fail("the unexpected exception should be thrown");
-        } catch(NullPointerException e) {
-            assertSame(testException, e);
+        } catch(AssertionError e) {
+            assertEquals("Expected a java.sql.SQLException to be thrown, but caught a java.lang.NullPointerException instead", e.getMessage());
+            assertSame(testException, e.getCause());
+        }
+    }
+
+    @Test
+    public void expectWithACodeBlockThatThrowsTheCorrectError() throws Exception {
+        final Error expectedError = new Error("The exception");
+        ExceptionSupplier<Error> supplier = new ExceptionSupplier<Error>() {
+            public void get() throws Exception {
+                throw expectedError;
+            }
+        };
+
+        Error actual = Assert.expect(Error.class, supplier);
+
+        assertSame(expectedError, actual);
+    }
+
+    @Test
+    public void expectWithACodeBlockThatDoesNotThrowAnError() throws Exception {
+        ExceptionSupplier<Error> supplier = new ExceptionSupplier<Error>() {
+            public void get() {
+                //do nothing
+            }
+        };
+
+        try {
+            Assert.expect(Error.class, supplier);
+            fail("expected an AssertionError to be thrown");
+        } catch (AssertionError e) {
+            assertEquals("Expected a java.lang.Error to be thrown", e.getMessage());
+        }
+    }
+
+    @Test
+    public void expectWithACodeBlockThatThrowsTheWrongKindOfError() throws Exception {
+        final Error theError = new Error("an exception not expected by the test");
+
+        try {
+            Assert.expect(SQLException.class, new ExceptionSupplier<SQLException>() {
+                public void get() {
+                    throw theError;
+                }
+            });
+            fail("the unexpected exception should be thrown");
+        } catch(AssertionError e) {
+            assertEquals("Expected a java.sql.SQLException to be thrown, but caught a java.lang.Error instead", e.getMessage());
+            assertSame(theError, e.getCause());
         }
     }
 }


### PR DESCRIPTION
There are generally two techniques for testing that a method throws an exception in a certain scenario.

The original technique is to use a try catch block:

```java
@Test
public void someTest() throws Exception {
    //some setup here
    try {
        doSomethingThatThrows();
        fail("expected a NullPointerException");
    } catch (NullPointerException e) {
        //optionally assert something about the exception
    }
}
```

This method is generally not preferred because it is verbose, and error-prone. Forgetting the `fail` statement is a really subtle failure case that can be easy to miss.

The newest method is to use the `expected` element of the `@Test` annotation:

```java
@Test(expected=NullPointerException.class)
public void someTest() throws Exception {
    //some setup here

    doSomethingThatThrows();
}
```

This method is less verbose, and much less complicated. However, it also has two significant drawbacks that are easy to overlook:

1. You cannot make any assertions about the exception once you encounter it.
2. If the specified exception is thrown *anywhere* in the test, the test will pass, even if the test isn't thrown from the expected statement.

In the above example, if a NullPointerException is thrown in the ```//some setup here`` block, the test will still pass!

This patch adds an additional way of testing for thrown exceptions:

```java
@Test(expected=NullPointerException.class)
public void someTest() throws Exception {
    //some setup here

    NullPointerException e = expect(NullPointerException.class, () -> doSomethingThatThrows());

    //optionally assert something about the exception
}
```

This mitigates the weaknesses of using the `expected` element of the `@Test` annotation: the exception must be thrown by calling `doSomethingThatThrows()`, or the test will fail; and the test can make assertions about the NullPointerException once it occurs.

This patch has been coded in such a way that it will compile and work with anonymous interface implementations in Java 5 or higher, although Java 8 lambda expressions are needed for the syntax to really be an improvement over the original pattern.

If no exceptions is thrown by the provided code block, then an `AssertionError` is thrown. If an exception other than the expected exception is thrown, then it will be rethrown by the `expect` method, which will cause the test to fail.