### PR TITLE
Fix compilation error caused by invalid Javadoc on JDK 8

### DIFF
--- a/src/main/java/org/junit/rules/TemporaryFolder.java
+++ b/src/main/java/org/junit/rules/TemporaryFolder.java
@@ -237,7 +237,7 @@ public class TemporaryFolder extends ExternalResource {
      * Delete all files and folders under the temporary folder. Usually not
      * called directly, since it is automatically applied by the {@link Rule}.
      *
-     * @throws {@code IllegalStateException} if unable to clean up resources
+     * @throws IllegalStateException if unable to clean up resources
      * and deletion of resources is assured.
      */
     public void delete() {


### PR DESCRIPTION
Since de92695 compilation fails (on Travis) using JDK 8 with the following error:

```
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR : 
[INFO] -------------------------------------------------------------
[ERROR] /home/travis/build/junit-team/junit/src/main/java/org/junit/rules/TemporaryFolder.java:[240,7] error: unexpected text
```

This is an attempt to fix it. Let't see what Travis thinks, now.