### PR TITLE
Changed line endings to LF

### DIFF
--- a/src/test/java/org/junit/tests/experimental/theories/extendingwithstubs/StubbedTheoriesTest.java
+++ b/src/test/java/org/junit/tests/experimental/theories/extendingwithstubs/StubbedTheoriesTest.java
@@ -1,1 +1,17 @@
-package org.junit.tests.experimental.theories.extendingwithstubs;import static org.hamcrest.CoreMatchers.is;import static org.junit.Assume.assumeThat;import org.junit.experimental.theories.Theory;import org.junit.runner.RunWith;@RunWith(StubbedTheories.class)public class StubbedTheoriesTest {    @Theory    public void ask(@Stub    Correspondent correspondent) {        assumeThat(correspondent.getAnswer("What is five?", "four", "five"),                is("five"));    }}
+package org.junit.tests.experimental.theories.extendingwithstubs;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assume.assumeThat;
+
+import org.junit.experimental.theories.Theory;
+import org.junit.runner.RunWith;
+
+@RunWith(StubbedTheories.class)
+public class StubbedTheoriesTest {
+    @Theory
+    public void ask(@Stub
+    Correspondent correspondent) {
+        assumeThat(correspondent.getAnswer("What is five?", "four", "five"),
+                is("five"));
+    }
+}


### PR DESCRIPTION
SonarQube had problems scanning this file because it believed it got
multiple blame annotations for the same line.
This seemed to be the only file with CR line endings, so I changed it
to LF which is consistent with the files in the same directory.