### PR TITLE
Use Timeout.millis(long) in javadoc for Timeout class

### DIFF
--- a/src/main/java/org/junit/rules/Timeout.java
+++ b/src/main/java/org/junit/rules/Timeout.java
@@ -12,7 +12,7 @@ import java.util.concurrent.TimeUnit;
  * public static class HasGlobalLongTimeout {
  *
  *  &#064;Rule
- *  public Timeout globalTimeout= new Timeout(20);
+ *  public Timeout globalTimeout = Timeout.millis(20);
  *
  *  &#064;Test
  *  public void run1() throws InterruptedException {


### PR DESCRIPTION
Javadoc for Timeout class should use Timeout.millis(long) instead of deprecated Timeout(int) constructor