### PR TITLE
Fixes some SonarQube issues

### DIFF
--- a/src/main/java/junit/textui/TestRunner.java
+++ b/src/main/java/junit/textui/TestRunner.java
@@ -131,7 +131,7 @@ public class TestRunner extends BaseTestRunner {
         }
     }
 
-    public static void main(String args[]) {
+    public static void main(String[] args) {
         TestRunner aTestRunner = new TestRunner();
         try {
             TestResult r = aTestRunner.start(args);
@@ -149,7 +149,7 @@ public class TestRunner extends BaseTestRunner {
      * Starts a test run. Analyzes the command line arguments and runs the given
      * test suite.
      */
-    public TestResult start(String args[]) throws Exception {
+    public TestResult start(String[] args) throws Exception {
         String testCase = "";
         String method = "";
         boolean wait = false;

--- a/src/main/java/org/junit/experimental/categories/Categories.java
+++ b/src/main/java/org/junit/experimental/categories/Categories.java
@@ -284,7 +284,7 @@ public class Categories extends Suite {
         }
 
         private static Set<Class<?>> copyAndRefine(Set<Class<?>> classes) {
-            HashSet<Class<?>> c= new HashSet<Class<?>>();
+            Set<Class<?>> c= new HashSet<Class<?>>();
             if (classes != null) {
                 c.addAll(classes);
             }

--- a/src/main/java/org/junit/internal/runners/TestClass.java
+++ b/src/main/java/org/junit/internal/runners/TestClass.java
@@ -85,7 +85,7 @@ public class TestClass {
     }
 
     private List<Class<?>> getSuperClasses(Class<?> testClass) {
-        ArrayList<Class<?>> results = new ArrayList<Class<?>>();
+        List<Class<?>> results = new ArrayList<Class<?>>();
         Class<?> current = testClass;
         while (current != null) {
             results.add(current);

--- a/src/main/java/org/junit/runner/notification/RunNotifier.java
+++ b/src/main/java/org/junit/runner/notification/RunNotifier.java
@@ -65,8 +65,8 @@ public class RunNotifier {
 
         void run() {
             int capacity = currentListeners.size();
-            ArrayList<RunListener> safeListeners = new ArrayList<RunListener>(capacity);
-            ArrayList<Failure> failures = new ArrayList<Failure>(capacity);
+            List<RunListener> safeListeners = new ArrayList<RunListener>(capacity);
+            List<Failure> failures = new ArrayList<Failure>(capacity);
             for (RunListener listener : currentListeners) {
                 try {
                     notifyListener(listener);

--- a/src/main/java/org/junit/runners/model/RunnerBuilder.java
+++ b/src/main/java/org/junit/runners/model/RunnerBuilder.java
@@ -96,7 +96,7 @@ public abstract class RunnerBuilder {
     }
 
     private List<Runner> runners(Class<?>[] children) {
-        ArrayList<Runner> runners = new ArrayList<Runner>();
+        List<Runner> runners = new ArrayList<Runner>();
         for (Class<?> each : children) {
             Runner childRunner = safeRunnerForClass(each);
             if (childRunner != null) {

--- a/src/main/java/org/junit/runners/model/TestClass.java
+++ b/src/main/java/org/junit/runners/model/TestClass.java
@@ -97,7 +97,7 @@ public class TestClass implements Annotatable {
 
     private static <T extends FrameworkMember<T>> Map<Class<? extends Annotation>, List<T>>
             makeDeeplyUnmodifiable(Map<Class<? extends Annotation>, List<T>> source) {
-        LinkedHashMap<Class<? extends Annotation>, List<T>> copy =
+        Map<Class<? extends Annotation>, List<T>> copy =
                 new LinkedHashMap<Class<? extends Annotation>, List<T>>();
         for (Map.Entry<Class<? extends Annotation>, List<T>> entry : source.entrySet()) {
             copy.put(entry.getKey(), Collections.unmodifiableList(entry.getValue()));
@@ -168,7 +168,7 @@ public class TestClass implements Annotatable {
     }
 
     private static List<Class<?>> getSuperClasses(Class<?> testClass) {
-        ArrayList<Class<?>> results = new ArrayList<Class<?>>();
+        List<Class<?>> results = new ArrayList<Class<?>>();
         Class<?> current = testClass;
         while (current != null) {
             results.add(current);

--- a/src/main/java/org/junit/validator/AnnotationsValidator.java
+++ b/src/main/java/org/junit/validator/AnnotationsValidator.java
@@ -116,5 +116,5 @@ public final class AnnotationsValidator implements TestClassValidator {
                 AnnotationValidator validator, FrameworkField field) {
             return validator.validateAnnotatedField(field);
         }
-    };
+    }
 }


### PR DESCRIPTION
- Moved array designators from the variable to the type
- Prefer interfaces over concrete classes. Note, there were a couple more cases where interfaces could be used instead, but some of them were part of public APIs so I haven't touched them for compatibility reasons.
- And removed an unnecessary semicolon