### PR TITLE
[Issue 1110] StopWatch does not need to be Abstract

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>junit</groupId>
@@ -102,6 +104,7 @@
 
     <properties>
         <jdkVersion>1.5</jdkVersion>
+        <surefireVersion>2.18.1</surefireVersion>
         <project.build.sourceEncoding>ISO-8859-1</project.build.sourceEncoding>
         <arguments />
         <gpg.keyname>67893CC4</gpg.keyname>
@@ -256,7 +259,7 @@
                 our junit suite "AllTests" after the sources are compiled.
                 -->
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>2.18.1</version>
+                <version>${surefireVersion}</version>
                 <configuration>
                     <test>org/junit/tests/AllTests.java</test>
                     <useSystemClassLoader>true</useSystemClassLoader>
@@ -540,7 +543,7 @@
                             <dependency>
                                 <groupId>org.apache.maven.surefire</groupId>
                                 <artifactId>surefire-junit47</artifactId>
-                                <version>2.18</version>
+                                <version>${surefireVersion}</version>
                             </dependency>
                         </dependencies>
                     </plugin>

--- a/src/main/java/org/junit/rules/Stopwatch.java
+++ b/src/main/java/org/junit/rules/Stopwatch.java
@@ -76,7 +76,7 @@ import java.util.concurrent.TimeUnit;
  * @author tibor17
  * @since 4.12
  */
-public abstract class Stopwatch implements TestRule {
+public class Stopwatch implements TestRule {
     private final Clock clock;
     private volatile long startNanos;
     private volatile long endNanos;


### PR DESCRIPTION
+ removed "abstract" class modifier
+ referenced surefire version via property
+ POM schema split in 3 lines