### PR TITLE
getRunnerAnnotations() returns all annotations other than 'RunWith'

### DIFF
--- a/src/main/java/org/junit/experimental/categories/Categories.java
+++ b/src/main/java/org/junit/experimental/categories/Categories.java
@@ -315,7 +315,6 @@ public class Categories extends Suite {
         } catch (NoTestsRemainException e) {
             throw new InitializationError(e);
         }
-        assertNoCategorizedDescendentsOfUncategorizeableParents(getDescription());
     }
 
     private static Set<Class<?>> getIncludedCategory(Class<?> klass) {
@@ -336,35 +335,6 @@ public class Categories extends Suite {
     private static boolean isAnyExcluded(Class<?> klass) {
         ExcludeCategory annotation= klass.getAnnotation(ExcludeCategory.class);
         return annotation == null || annotation.matchAny();
-    }
-
-    private static void assertNoCategorizedDescendentsOfUncategorizeableParents(Description description) throws InitializationError {
-        if (canHaveCategorizedChildren(description)) {
-            for (Description each : description.getChildren()) {
-                assertNoCategorizedDescendentsOfUncategorizeableParents(each);
-            }
-        } else {
-            assertNoDescendantsHaveCategoryAnnotations(description);
-        }
-    }
-
-    private static void assertNoDescendantsHaveCategoryAnnotations(Description description) throws InitializationError {
-        for (Description each : description.getChildren()) {
-            if (each.getAnnotation(Category.class) != null) {
-                throw new InitializationError("Category annotations on Parameterized classes are not supported on individual methods.");
-            }
-            assertNoDescendantsHaveCategoryAnnotations(each);
-        }
-    }
-
-    // If children have names like [0], our current magical category code can't determine their parentage.
-    private static boolean canHaveCategorizedChildren(Description description) {
-        for (Description each : description.getChildren()) {
-            if (each.getTestClass() == null) {
-                return false;
-            }
-        }
-        return true;
     }
 
     private static boolean hasAssignableTo(Set<Class<?>> assigns, Class<?> to) {

--- a/src/main/java/org/junit/runners/parameterized/BlockJUnit4ClassRunnerWithParameters.java
+++ b/src/main/java/org/junit/runners/parameterized/BlockJUnit4ClassRunnerWithParameters.java
@@ -4,6 +4,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
 import java.util.List;
 
+import org.junit.runner.RunWith;
 import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.Parameterized.Parameter;
@@ -130,10 +131,19 @@ public class BlockJUnit4ClassRunnerWithParameters extends
 
     @Override
     protected Annotation[] getRunnerAnnotations() {
-        return new Annotation[0];
+		Annotation[] allAnnotations = super.getRunnerAnnotations();
+		Annotation[] annotationsWithoutRunWith = new Annotation[allAnnotations.length - 1];
+		int i = 0;
+		for (Annotation annotation: allAnnotations) {
+			if (!annotation.annotationType().equals(RunWith.class)) {
+				annotationsWithoutRunWith[i] = annotation;
+				++i;
+			}
+		}
+		return annotationsWithoutRunWith;
     }
 
-    private List<FrameworkField> getAnnotatedFieldsByParameter() {
+	private List<FrameworkField> getAnnotatedFieldsByParameter() {
         return getTestClass().getAnnotatedFields(Parameter.class);
     }
 

--- a/src/test/java/org/junit/runners/parameterized/BlockJUnit4ClassRunnerWithParametersTest.java
+++ b/src/test/java/org/junit/runners/parameterized/BlockJUnit4ClassRunnerWithParametersTest.java
@@ -1,0 +1,38 @@
+package org.junit.runners.parameterized;
+
+import static java.util.Collections.emptyList;
+import static org.junit.Assert.assertEquals;
+
+import java.lang.annotation.*;
+import java.util.List;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.model.TestClass;
+
+public class BlockJUnit4ClassRunnerWithParametersTest {
+	private static final List<Object> NO_PARAMETERS = emptyList();
+
+	@RunWith(Parameterized.class)
+	@DummyAnnotation
+	public static class ClassWithParameterizedAnnotation {
+		@Test
+		public void dummyTest() {
+		}
+	}
+
+	@Test
+	public void hasAllAnnotationsExceptRunWith() throws Exception {
+		TestWithParameters testWithParameters = new TestWithParameters("dummy name", new TestClass(ClassWithParameterizedAnnotation.class), NO_PARAMETERS);
+		BlockJUnit4ClassRunnerWithParameters runner = new BlockJUnit4ClassRunnerWithParameters(testWithParameters);
+		Annotation[] annotations = runner.getRunnerAnnotations();
+		assertEquals(1, annotations.length);
+		assertEquals(annotations[0].annotationType(), DummyAnnotation.class);
+	}
+
+	@Retention(RetentionPolicy.RUNTIME)
+	@Target(ElementType.TYPE)
+	private static @interface DummyAnnotation {
+	}
+}

--- a/src/test/java/org/junit/tests/AllTests.java
+++ b/src/test/java/org/junit/tests/AllTests.java
@@ -24,6 +24,7 @@ import org.junit.runners.Suite.SuiteClasses;
 import org.junit.runners.model.FrameworkFieldTest;
 import org.junit.runners.model.FrameworkMethodTest;
 import org.junit.runners.model.TestClassTest;
+import org.junit.runners.parameterized.BlockJUnit4ClassRunnerWithParametersTest;
 import org.junit.runners.parameterized.ParameterizedNamesTest;
 import org.junit.runners.parameterized.TestWithParametersTest;
 import org.junit.tests.assertion.AssertionTest;
@@ -222,6 +223,7 @@ import org.junit.validator.PublicClassValidatorTest;
         JUnitCoreTest.class,
         TestWithParametersTest.class,
         ParameterizedNamesTest.class,
+        BlockJUnit4ClassRunnerWithParametersTest.class,
         PublicClassValidatorTest.class,
         DisableOnDebugTest.class,
         ThrowableCauseMatcherTest.class,

--- a/src/test/java/org/junit/tests/experimental/categories/CategoriesAndParameterizedTest.java
+++ b/src/test/java/org/junit/tests/experimental/categories/CategoriesAndParameterizedTest.java
@@ -1,18 +1,18 @@
 package org.junit.tests.experimental.categories;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 import static org.junit.experimental.results.PrintableResult.testResult;
-import static org.junit.experimental.results.ResultMatchers.hasFailureContaining;
-import static org.junit.experimental.results.ResultMatchers.isSuccessful;
 
-import java.util.Collection;
-import java.util.Collections;
+import java.util.Arrays;
 
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Categories;
 import org.junit.experimental.categories.Categories.IncludeCategory;
 import org.junit.experimental.categories.Category;
+import org.junit.runner.JUnitCore;
+import org.junit.runner.Result;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
@@ -24,14 +24,14 @@ public class CategoriesAndParameterizedTest {
     }
 
     @RunWith(Parameterized.class)
-    public static class WellBehavedParameterizedTest {
-        public WellBehavedParameterizedTest(String a) {
-        }
-
+    public static class ParameterizedTestWithoutCategory {
         @Parameters
-        public static Collection<Object[]> getParameters() {
-            return Collections.singletonList(new Object[]{"a"});
-        }
+        public static Iterable<String> getParameters() {
+            return Arrays.asList("first", "second");
+		}
+
+		@Parameterized.Parameter
+		public String value;
 
         @Test
         public void testSomething() {
@@ -39,85 +39,84 @@ public class CategoriesAndParameterizedTest {
         }
     }
 
-    @RunWith(Parameterized.class)
-    public static class ParameterizedTestWithAttemptedMethodCategory {
-        public ParameterizedTestWithAttemptedMethodCategory(String a) {
-        }
+	@Category(Token.class)
+	public static class TestThatAvoidsNoTestRemainsException {
+		@Test
+		public void testSomething() {
+			Assert.assertTrue(true);
+		}
+	}
 
-        @Parameters
-        public static Collection<Object[]> getParameters() {
-            return Collections.singletonList(new Object[]{"a"});
-        }
+	@RunWith(Categories.class)
+	@IncludeCategory(Token.class)
+	@SuiteClasses({TestThatAvoidsNoTestRemainsException.class, ParameterizedTestWithoutCategory.class})
+	public static class SuiteWithParameterizedTestWithoutCategory {
+	}
 
-        @Test
-        @Category(Token.class)
-        public void testSomething() {
-            Assert.assertTrue(true);
-        }
-    }
+	@Test
+	public void doesNotRunTestsWithoutCategory() {
+		Result result = new JUnitCore().run(SuiteWithParameterizedTestWithoutCategory.class);
+		assertEquals(1, result.getRunCount());
+		assertEquals(0, result.getFailureCount());
+	}
 
-    @RunWith(Parameterized.class)
-    @Category(Token.class)
-    public static class ParameterizedTestWithClassCategory {
-        public ParameterizedTestWithClassCategory(String a) {
-        }
+	@RunWith(Parameterized.class)
+	@Category(Token.class)
+	public static class ParameterizedTestWithCategory {
+		@Parameters
+		public static Iterable<String> getParameters() {
+			return Arrays.asList("first", "second");
+		}
 
-        @Parameters
-        public static Collection<Object[]> getParameters() {
-            return Collections.singletonList(new Object[]{"a"});
-        }
+		@Parameterized.Parameter
+		public String value;
 
-        @Test
-        public void testSomething() {
-            Assert.assertTrue(true);
-        }
-    }
+		@Test
+		public void testSomething() {
+			Assert.assertTrue(true);
+		}
+	}
 
-    @Category(Token.class)
-    public static class VanillaCategorizedJUnitTest {
-        @Test
-        public void testSomething() {
-            Assert.assertTrue(true);
-        }
-    }
+	@RunWith(Categories.class)
+	@IncludeCategory(Token.class)
+	@SuiteClasses({ParameterizedTestWithCategory.class})
+	public static class SuiteWithParameterizedTestWithCategory {
+	}
 
-    @RunWith(Categories.class)
-    @IncludeCategory(Token.class)
-    @SuiteClasses({VanillaCategorizedJUnitTest.class,
-            WellBehavedParameterizedTest.class,
-            ParameterizedTestWithClassCategory.class})
-    public static class ParameterTokenSuiteWellFormed {
-    }
+	@Test
+	public void runsTestsWithoutCategory() {
+		Result result = new JUnitCore().run(SuiteWithParameterizedTestWithCategory.class);
+		assertEquals(2, result.getRunCount());
+		assertEquals(0, result.getFailureCount());
+	}
 
-    @RunWith(Categories.class)
-    @IncludeCategory(Token.class)
-    @SuiteClasses({ParameterizedTestWithAttemptedMethodCategory.class, VanillaCategorizedJUnitTest.class})
-    public static class ParameterTokenSuiteMalformed {
-    }
+	@RunWith(Parameterized.class)
+	public static class ParameterizedTestWithMethodWithCategory {
+		@Parameters
+		public static Iterable<String> getParameters() {
+			return Arrays.asList("first", "second");
+		}
 
-    @RunWith(Categories.class)
-    @IncludeCategory(Token.class)
-    @SuiteClasses({VanillaCategorizedJUnitTest.class, ParameterizedTestWithAttemptedMethodCategory.class})
-    public static class ParameterTokenSuiteMalformedAndSwapped {
-    }
+		@Parameterized.Parameter
+		public String value;
 
-    @Test
-    public void shouldSucceedWithAParameterizedClassSomewhere() {
-        assertThat(testResult(ParameterTokenSuiteWellFormed.class),
-                isSuccessful());
-    }
+		@Test
+		@Category(Token.class)
+		public void testSomething() {
+			Assert.assertTrue(true);
+		}
+	}
 
-    @Test
-    public void shouldFailWithMethodLevelCategoryAnnotation() {
-        assertThat(
-                testResult(ParameterTokenSuiteMalformed.class),
-                hasFailureContaining("Category annotations on Parameterized classes are not supported on individual methods."));
-    }
+	@RunWith(Categories.class)
+	@IncludeCategory(Token.class)
+	@SuiteClasses({ParameterizedTestWithMethodWithCategory.class})
+	public static class SuiteWithParameterizedTestWithMethodWithCategory {
+	}
 
-    @Test
-    public void shouldFailWithMethodLevelCategoryAnnotationSwapped() {
-        assertThat(
-                testResult(ParameterTokenSuiteMalformedAndSwapped.class),
-                hasFailureContaining("Category annotations on Parameterized classes are not supported on individual methods."));
-    }
+	@Test
+	public void runsTestMethodWithCategory() {
+		Result result = new JUnitCore().run(SuiteWithParameterizedTestWithMethodWithCategory.class);
+		assertEquals(2, result.getRunCount());
+		assertEquals(0, result.getFailureCount());
+	}
 }


### PR DESCRIPTION
Resolves conflicts between @stefanbirkner's branch and `master`, and adds his test case to the ones run by Maven. Fixes #751.