### PR TITLE
Handling of StoppedByUserException will correctly stop execution in case of any additional errors coming from @AfterClass methods or class rules.

### DIFF
--- a/src/test/java/org/junit/tests/listening/UserStopTest.java
+++ b/src/test/java/org/junit/tests/listening/UserStopTest.java
@@ -1,23 +1,41 @@
 package org.junit.tests.listening;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.AfterClass;
 import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.runner.Request;
+import org.junit.runner.RunWith;
+import org.junit.runner.notification.Failure;
+import org.junit.runner.notification.RunListener;
 import org.junit.runner.notification.RunNotifier;
 import org.junit.runner.notification.StoppedByUserException;
+import org.junit.runners.Suite;
+import org.junit.runners.Suite.SuiteClasses;
 
 public class UserStopTest {
-    private RunNotifier fNotifier;
+    private RunNotifier runNotifier;
+    private static final List<String> invocations = new ArrayList<String>();
 
     @Before
     public void createNotifier() {
-        fNotifier = new RunNotifier();
-        fNotifier.pleaseStop();
+        invocations.clear();
+        
+        runNotifier = new RunNotifier();
+        runNotifier.pleaseStop();
     }
 
     @Test(expected = StoppedByUserException.class)
     public void userStop() {
-        fNotifier.fireTestStarted(null);
+        runNotifier.fireTestStarted(null);
     }
 
     public static class OneTest {
@@ -28,6 +46,66 @@ public class UserStopTest {
 
     @Test(expected = StoppedByUserException.class)
     public void stopClassRunner() throws Exception {
-        Request.aClass(OneTest.class).getRunner().run(fNotifier);
+        Request.aClass(OneTest.class).getRunner().run(runNotifier);
+    }
+    
+    @RunWith(Suite.class)
+    @SuiteClasses({TestClassWithExceptionInAfterClass.class,
+        TestClassThatShouldNotBeExecuted.class})
+    public static class SuiteExample {}
+    
+    public static class TestClassWithExceptionInAfterClass {
+        @Test
+        public void test() {}
+        
+        @AfterClass
+        public static void afterClass() {
+            throw new RuntimeException("Exception");
+        }
+    }
+    
+    public static class TestClassThatShouldNotBeExecuted {
+        @BeforeClass
+        public static void beforeClass() {
+            invocations.add("beforeClass");
+        }
+        
+        @Test
+        public void test() {
+            invocations.add("test");
+        }
+        
+        @AfterClass
+        public static void afterClass() {
+            invocations.add("afterClass");
+        }
+    }
+    
+    /**
+     * Verifies that stop request is properly handled for suite execution in 
+     * case of additional execution errors coming from {@link AfterClass} 
+     * method or {@link ClassRule}, i.e.: <br />
+     * - no methods from subsequent classes should be executed <br />
+     * - listeners still should be notified about execution errors except 
+     * {@link StoppedByUserException}.
+     */
+    @Test
+    public void testHandlingStopRequestWithAdditionalExecutionErrors() {
+        final List<String> failures = new ArrayList<String>();
+        
+        runNotifier.addListener(new RunListener() {
+            @Override
+            public void testFailure(Failure failure) throws Exception {
+                failures.add(failure.getMessage());
+            }
+        });
+        
+        try {
+            Request.aClass(SuiteExample.class).getRunner().run(runNotifier);
+            fail();
+        } catch (StoppedByUserException e) {
+            assertEquals(0, invocations.size());
+            assertEquals(Arrays.asList("Exception"), failures);
+        }
     }
 }


### PR DESCRIPTION
Due to #1125.

Several points:
1. Original code did not notify listeners about StoppedByUserException. I took the same approach for handling this exception with other execution errors - StoppedByUserException will not be delivered to listeners while all other errors will. Though I think listeners should get notification about reason of execution interruption.
2. Method for unpacking all exceptions looks a little bit helpful and at the moment the same logic is used in EachTestNotifier. I was thinking about moving that method to MultipleFailureException class to make it common and allow usage of one in different places (e.g. writers of custom runners can get benefit from one), but in that case method will become a part of the public API, and I'm not sure that JUnit needs that.
3. I don't like methods' names, but was unable to find something more appropriate.