### PR TITLE
EPL agreement will be shown for new pull requests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,13 @@
+### Project License:  Eclipse Public License v1.0
+
+- You will only Submit Contributions where You have authored 100% of the content.
+- You will only Submit Contributions to which You have the necessary rights. This means that if You are employed You have received the necessary permissions from Your employer to make the Contributions.
+- Whatever content You Contribute will be provided under the Project License(s).
+
+---
+
+### How to submit a pull request
+
 We love pull requests. Here is a quick guide:
 
 1. You need to have Maven and a JDK (at least version 1.5) installed.


### PR DESCRIPTION
The Eclipse Foundation requires that all contributors agree to these
terms so that Eclipse can continue to ship with Eclipse.