### PR TITLE
Removed usage of Double Checked Locking.

### DIFF
--- a/src/main/java/org/junit/internal/requests/ClassRequest.java
+++ b/src/main/java/org/junit/internal/requests/ClassRequest.java
@@ -27,11 +27,9 @@ public class ClassRequest extends Request {
 
     @Override
     public Runner getRunner() {
-        if (runner == null) {
-            synchronized (runnerLock) {
-                if (runner == null) {
-                    runner = new AllDefaultPossibilitiesBuilder(canUseSuiteMethod).safeRunnerForClass(fTestClass);
-                }
+        synchronized (runnerLock) {
+            if (runner == null) {
+                runner = new AllDefaultPossibilitiesBuilder(canUseSuiteMethod).safeRunnerForClass(fTestClass);
             }
         }
         return runner;


### PR DESCRIPTION
Given that Double Checked Locking is not thread safe, it should not be used.