### PR TITLE
JavaDoc Clean-up Rules Implement TestRule (redo)

### DIFF
--- a/src/main/java/org/junit/rules/MethodRule.java
+++ b/src/main/java/org/junit/rules/MethodRule.java
@@ -10,7 +10,7 @@ import org.junit.runners.model.Statement;
  * {@link Statement} that executes the method is passed to each annotated
  * {@link Rule} in turn, and each may return a substitute or modified
  * {@link Statement}, which is passed to the next {@link Rule}, if any. For
- * and example of how this can be useful, see {@link TestWatchman}.
+ * an example of how this can be useful, see {@link TestWatchman}.
  *
  * Note that {@link MethodRule} has been replaced by {@link TestRule},
  * which has the added benefit of supporting class rules.

--- a/src/main/java/org/junit/rules/MethodRule.java
+++ b/src/main/java/org/junit/rules/MethodRule.java
@@ -10,19 +10,7 @@ import org.junit.runners.model.Statement;
  * {@link Statement} that executes the method is passed to each annotated
  * {@link Rule} in turn, and each may return a substitute or modified
  * {@link Statement}, which is passed to the next {@link Rule}, if any. For
- * examples of how this can be useful, see these provided MethodRules,
- * or write your own:
- *
- * <ul>
- *   <li>{@link ErrorCollector}: collect multiple errors in one test method</li>
- *   <li>{@link ExpectedException}: make flexible assertions about thrown exceptions</li>
- *   <li>{@link ExternalResource}: start and stop a server, for example</li>
- *   <li>{@link TemporaryFolder}: create fresh files, and delete after test</li>
- *   <li>{@link TestName}: remember the test name for use during the method</li>
- *   <li>{@link TestWatchman}: add logic at events during method execution</li>
- *   <li>{@link Timeout}: cause test to fail after a set time</li>
- *   <li>{@link Verifier}: fail test if object state ends up incorrect</li>
- * </ul>
+ * and example of how this can be useful, see {@link TestWatchman}.
  *
  * Note that {@link MethodRule} has been replaced by {@link TestRule},
  * which has the added benefit of supporting class rules.


### PR DESCRIPTION
Redo the original pull request. This cleans up the JavaDoc, removing links to classes which no longer implement this interface.