### PR TITLE
TestName: Make 'name' field volatile

### DIFF
--- a/src/main/java/org/junit/rules/TestName.java
+++ b/src/main/java/org/junit/rules/TestName.java
@@ -25,7 +25,7 @@ import org.junit.runner.Description;
  * @since 4.7
  */
 public class TestName extends TestWatcher {
-    private String name;
+    private volatile String name;
 
     @Override
     protected void starting(Description d) {


### PR DESCRIPTION
This ensures that the name is published across threads correctly--for
instance, if a parallelized runner is used.