### PR TITLE
RFC: TestRule potpourri

### DIFF
--- a/src/main/java/org/junit/Repeat.java
+++ b/src/main/java/org/junit/Repeat.java
@@ -1,0 +1,12 @@
+package org.junit;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Repeat {
+    int value() default 1;
+}

--- a/src/main/java/org/junit/rules/ParallelRepeatRule.java
+++ b/src/main/java/org/junit/rules/ParallelRepeatRule.java
@@ -1,0 +1,63 @@
+package org.junit.rules;
+
+import org.junit.Repeat;
+import org.junit.runner.Description;
+import org.junit.runners.model.MultipleFailureException;
+import org.junit.runners.model.Statement;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+
+public class ParallelRepeatRule implements TestRule {
+    private final ExecutorService executorService;
+
+    public ParallelRepeatRule(ExecutorService executorService) {
+        this.executorService = executorService;
+    }
+
+    public Statement apply(final Statement base, Description description) {
+        Repeat annotation = description.getAnnotation(Repeat.class);
+        final int iterations = annotation == null ? 1 : annotation.value();
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                List<Future<?>> futures = new ArrayList<Future<?>>();
+                for (int i = 0; i < iterations; i++) {
+                    futures.add(executorService.submit(new Callable<Void>() {
+                        public Void call() throws Exception {
+                            try {
+                                base.evaluate();
+                                return null;
+                            } catch (Exception ex) {
+                                throw ex;
+                            } catch (Throwable t) {
+                                throw new RuntimeException(t);
+                            }
+                        }
+                    }));
+                }
+                List<Throwable> throwables = new ArrayList<Throwable>();
+                boolean interrupted = false;
+                for (Future<?> future : futures) {
+                    try {
+                        future.get();
+                    } catch (ExecutionException ex) {
+                        throwables.add(ex.getCause());
+                    } catch (InterruptedException ex) {
+                        interrupted = true;
+                    }
+                }
+                if (interrupted) {
+                    Thread.currentThread().interrupt();
+                }
+                if (!throwables.isEmpty()) {
+                    throw new MultipleFailureException(throwables);
+                }
+            }
+        };
+    }
+}

--- a/src/main/java/org/junit/rules/RepeatRule.java
+++ b/src/main/java/org/junit/rules/RepeatRule.java
@@ -1,0 +1,30 @@
+package org.junit.rules;
+
+import org.junit.Repeat;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public class RepeatRule implements TestRule {
+    private final int runs;
+
+    public RepeatRule() {
+        this.runs = 1;
+    }
+
+    public RepeatRule(int runs) {
+        this.runs = runs;
+    }
+
+    public Statement apply(final Statement base, Description description) {
+        Repeat annotation = description.getAnnotation(Repeat.class);
+        final int iterations = annotation == null ? runs : annotation.value();
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                for (int i = 0; i < iterations; i++) {
+                    base.evaluate();
+                }
+            }
+        };
+    }
+}

--- a/src/main/java/org/junit/rules/RetryDecider.java
+++ b/src/main/java/org/junit/rules/RetryDecider.java
@@ -1,0 +1,7 @@
+package org.junit.rules;
+
+public interface RetryDecider {
+    void reportSuccess();
+
+    boolean reportFailure(Throwable throwable);
+}

--- a/src/main/java/org/junit/rules/RetryRule.java
+++ b/src/main/java/org/junit/rules/RetryRule.java
@@ -1,0 +1,31 @@
+package org.junit.rules;
+
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+public class RetryRule implements TestRule {
+    private final RetryDecider retryDecider;
+
+    public RetryRule(RetryDecider retryDecider) {
+        this.retryDecider = retryDecider;
+    }
+
+    public Statement apply(final Statement base, Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                while (true) {
+                    try {
+                        base.evaluate();
+                        retryDecider.reportSuccess();
+                        return;
+                    } catch (Throwable t) {
+                        if (!retryDecider.reportFailure(t)) {
+                            throw t;
+                        }
+                    }
+                }
+            }
+        };
+    }
+}

--- a/src/test/java/org/junit/tests/experimental/rules/RepeatRuleTest.java
+++ b/src/test/java/org/junit/tests/experimental/rules/RepeatRuleTest.java
@@ -1,0 +1,31 @@
+package org.junit.tests.experimental.rules;
+
+import org.junit.Assert;
+import org.junit.Repeat;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ParallelRepeatRule;
+
+import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+public class RepeatRuleTest {
+    private static final ExecutorService executorService = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors());
+    private static final Random R = new Random();
+
+    @Rule public ParallelRepeatRule parallelRepeatRule = new ParallelRepeatRule(executorService);
+
+    @Test
+    @Repeat(1000)
+    public void asdf() {
+        byte[] buf = new byte[1048576];
+        R.nextBytes(buf);
+    }
+
+    @Test
+    @Repeat(10)
+    public void asdf2() {
+        Assert.assertTrue(false);
+    }
+}


### PR DESCRIPTION
This is a sketch of a few TestRules I would find useful.

* `RepeatRule` repeats tests some constant number of times.
* `ParallelRepeatRule` is a parallel version of `RepeatRule` that executes tests in the supplied thread pool.
* `RetryRule` uses an injectible retry policy to decide whether failed tests should be retried.

The intended use of the first two is simple generative tests, where test cases are generated nondeterministically and some specific invariant is asserted (e.g. round-trip tests for serialization). The `RetryRule` is intended for use with integration tests that may fail spuriously. Whether to retry is decided by another object (which should probably be some kind of `TestWatcher` instance); the intention is to support different types of retry strategies, such as:

* Retry a fixed number of times per method
* Retry a fixed number of times per class
* Budget a global number of retries
* Only retry certain exceptions
* Retry unless too many failures (within some scope--suite, class...) have been observed recently

I searched GitHub to look for prior issues/PRs like this, but the only related-looking thing I found was a class in `junit.framework`. This strikes me as pretty straightforward and useful functionality, so I want to see what the project maintainers think. Which of these suggestions are viable?