### PR TITLE
Let maven replacer plugin use sourceDirectory property.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -199,8 +199,8 @@
                 </executions>
                 <configuration>
                     <ignoreMissingFile>false</ignoreMissingFile>
-                    <file>src/main/java/junit/runner/Version.java.template</file>
-                    <outputFile>src/main/java/junit/runner/Version.java</outputFile>
+                    <file>${project.build.sourceDirectory}/junit/runner/Version.java.template</file>
+                    <outputFile>${project.build.sourceDirectory}/junit/runner/Version.java</outputFile>
                     <regex>false</regex>
                     <token>@version@</token>
                     <value>${project.version}</value>


### PR DESCRIPTION
The old maven replacer plugin was configured with a relative link to the source path.

This caused a failure of

    mvn -f path-to-junit/pom.xml

The modified pom file uses the `project.build.sourceDirectory` property, which solves this problem.