### PR TITLE
Fix #1169 Throwing MultipleFailureException with empty list of throwables forces test to fail, and modify MultipleFailureException.getMessage()

### DIFF
--- a/src/main/java/org/junit/internal/runners/model/EachTestNotifier.java
+++ b/src/main/java/org/junit/internal/runners/model/EachTestNotifier.java
@@ -25,6 +25,9 @@ public class EachTestNotifier {
     }
 
     private void addMultipleFailureException(MultipleFailureException mfe) {
+        if(mfe.getFailures().isEmpty()) {
+            notifier.fireTestFailure(new Failure(description, mfe));
+        }
         for (Throwable each : mfe.getFailures()) {
             addFailure(each);
         }

--- a/src/main/java/org/junit/runners/model/MultipleFailureException.java
+++ b/src/main/java/org/junit/runners/model/MultipleFailureException.java
@@ -31,6 +31,9 @@ public class MultipleFailureException extends Exception {
 
     @Override
     public String getMessage() {
+        if(fErrors.isEmpty()) {
+            return this.getClass().getName();
+        }
         StringBuilder sb = new StringBuilder(
                 String.format("There were %d errors:", fErrors.size()));
         for (Throwable e : fErrors) {

--- a/src/test/java/org/junit/tests/running/classes/ParentRunnerTest.java
+++ b/src/test/java/org/junit/tests/running/classes/ParentRunnerTest.java
@@ -5,6 +5,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
 
+import java.util.Collections;
 import java.util.List;
 
 import org.hamcrest.Matcher;
@@ -25,6 +26,7 @@ import org.junit.runner.notification.RunNotifier;
 import org.junit.runners.BlockJUnit4ClassRunner;
 import org.junit.runners.ParentRunner;
 import org.junit.runners.model.InitializationError;
+import org.junit.runners.model.MultipleFailureException;
 import org.junit.runners.model.RunnerScheduler;
 import org.junit.tests.experimental.rules.RuleMemberValidatorTest.TestWithNonStaticClassRule;
 import org.junit.tests.experimental.rules.RuleMemberValidatorTest.TestWithProtectedClassRule;
@@ -213,14 +215,19 @@ public class ParentRunnerTest {
         public void assumptionFail() {
             throw new AssumptionViolatedException("Thrown from @Test");
         }
+
+        @Test
+        public void MultipleFailureExceptionFail() throws Exception {
+            throw new MultipleFailureException(Collections.<Throwable>emptyList());
+        }
     }
 
     @Test
     public void parentRunnerTestMethods() throws InitializationError {
         CountingRunListener countingRunListener = runTestWithParentRunner(TestTest.class);
-        Assert.assertEquals(3, countingRunListener.testStarted);
-        Assert.assertEquals(3, countingRunListener.testFinished);
-        Assert.assertEquals(1, countingRunListener.testFailure);
+        Assert.assertEquals(4, countingRunListener.testStarted);
+        Assert.assertEquals(4, countingRunListener.testFinished);
+        Assert.assertEquals(2, countingRunListener.testFailure);
         Assert.assertEquals(1, countingRunListener.testAssumptionFailure);
         Assert.assertEquals(1, countingRunListener.testIgnored);
     }


### PR DESCRIPTION
Fix #1169 Throwing `MultipleFailureException` with empty list of throwables forces test to fail, and modify `MultipleFailureException.getMessage()`.

Note: 
- @kcooney Throwing `IllegalArguementException` in constructor works fine, except `@Test(expected = MultipleFailureException.class)` will be fail.

- The [previous pull-request](https://github.com/ShengyuanLu/junit/commit/71b17fdde564535e51ccdf2390b0cb3bd1ca342d) is buggy, this is latest one. 

Thanks!