### PR TITLE
Avoid calling a deprecated constructor in the JavaDoc sample for the …

### DIFF
--- a/src/main/java/org/junit/rules/Timeout.java
+++ b/src/main/java/org/junit/rules/Timeout.java
@@ -13,7 +13,7 @@ import java.util.concurrent.TimeUnit;
  * public static class HasGlobalLongTimeout {
  *
  *  &#064;Rule
- *  public Timeout globalTimeout= new Timeout(20);
+ *  public Timeout globalTimeout = Timeout.millis(20);
  *
  *  &#064;Test
  *  public void run1() throws InterruptedException {


### PR DESCRIPTION
…Timeout rule.

In the JavaDocs for the `Timeout` rule, there is a code sample that uses a constructor that has been deprecated.  This patch is a change in JavaDocs only to avoid using the deprecated constructor, and hence prevent spreading usage of the deprecated constructor by developers copy-pasting the sample.  Thank you!