### PR TITLE
Minor fix to javadoc of the RuleChain.around method (nextRule should …

### DIFF
--- a/src/main/java/org/junit/rules/RuleChain.java
+++ b/src/main/java/org/junit/rules/RuleChain.java
@@ -72,7 +72,7 @@ public class RuleChain implements TestRule {
     }
 
     /**
-     * Create a new {@code RuleChain}, which encloses the {@code enclosedRule} with
+     * Create a new {@code RuleChain}, which encloses the given {@link TestRule} with
      * the rules of the current {@code RuleChain}.
      *
      * @param enclosedRule the rule to enclose.

--- a/src/main/java/org/junit/rules/RuleChain.java
+++ b/src/main/java/org/junit/rules/RuleChain.java
@@ -72,7 +72,7 @@ public class RuleChain implements TestRule {
     }
 
     /**
-     * Create a new {@code RuleChain}, which encloses the {@code nextRule} with
+     * Create a new {@code RuleChain}, which encloses the {@code enclosedRule} with
      * the rules of the current {@code RuleChain}.
      *
      * @param enclosedRule the rule to enclose.


### PR DESCRIPTION
…be enclosedRule, assuming it's referring to the method parameter).