### PR TITLE
License link on junit.org

### DIFF
--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -91,6 +91,7 @@
             <li><a href="javadoc/latest/index.html">JavaDocs</a></li>
             <li><a href="./faq.html">Frequently asked questions</a></li>
             <li><a href="https://github.com/junit-team/junit/wiki">Wiki</a></li>
+            <li><a href="./license.html">License</a></li>
           </ul>
         </div>
         <div class="span4" id="concepts-section">


### PR DESCRIPTION
Added prominent link to the project's license.

This patch fixes #1162.

Signed-off-by: Allon Mureinik <mureinik@gmail.com>