### PR TITLE
Fix typo and formatting in JavaDoc

### DIFF
--- a/src/main/java/org/junit/rules/ExpectedException.java
+++ b/src/main/java/org/junit/rules/ExpectedException.java
@@ -20,7 +20,7 @@ import org.junit.runners.model.Statement;
  *
  * <pre> public class SimpleExpectedExceptionTest {
  *     &#064;Rule
- *     public ExpectedException thrown= ExpectedException.none();
+ *     public ExpectedException thrown = ExpectedException.none();
  *
  *     &#064;Test
  *     public void throwsNothing() {
@@ -43,7 +43,7 @@ import org.junit.runners.model.Statement;
  *
  * <p>
  * Instead of specifying the exception's type you can characterize the
- * expected exception based on other criterias, too:
+ * expected exception based on other criteria, too:
  *
  * <ul>
  *   <li>The exception's message contains a specific text: {@link #expectMessage(String)}</li>


### PR DESCRIPTION
Just two minor fixes: missing space in code snippet and typo in `ExpectedException`'s JavaDoc.