### PR TITLE
createTestClass with throws InitializationError

### DIFF
--- a/src/main/java/org/junit/runners/ParentRunner.java
+++ b/src/main/java/org/junit/runners/ParentRunner.java
@@ -84,7 +84,7 @@ public abstract class ParentRunner<T> extends Runner implements Filterable,
         validate();
     }
 
-    protected TestClass createTestClass(Class<?> testClass) {
+    protected TestClass createTestClass(Class<?> testClass) throws InitializationError {
         return new TestClass(testClass);
     }
 


### PR DESCRIPTION
I'm @Override createTestClass() and in my implementation things could go wrong and it would thus be handy if createTestClass had with throws InitializationError, just like the called constructor ParentRunner anyway already does.