### PR TITLE
Add evaluatePostcheck method to ExpectedException rule.

### DIFF
--- a/src/main/java/org/junit/rules/ExpectedException.java
+++ b/src/main/java/org/junit/rules/ExpectedException.java
@@ -248,10 +248,11 @@ public class ExpectedException implements TestRule {
      * public void throwsExceptionWithSpecificType() {
      *     thrown.expect(NullPointerException.class);
      *     thrown.evaluatePostcheck(new Runnable() {
-     *         @Override
+     *         &#064;Override
      *         public void run() {
-     *             // additional checks (e.g. whether a mock was called before
-     *             // the test threw the exception)
+     *             // Additional checks (e.g. whether a mock was called before
+     *             // the test threw an exception). This will be called after
+     *             // the exception is caught and verified.
      *         }
      *     });
      *     throw new NullPointerException();

--- a/src/test/java/org/junit/tests/experimental/rules/ExpectedExceptionTest.java
+++ b/src/test/java/org/junit/tests/experimental/rules/ExpectedExceptionTest.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 
 import org.hamcrest.CoreMatchers;
 import org.hamcrest.Matcher;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -87,7 +88,10 @@ public class ExpectedExceptionTest {
                 {
                         UseCustomMessageWithPlaceHolder.class,
                         hasSingleFailureWithMessage(ARBITRARY_MESSAGE
-                                + " - an instance of java.lang.IllegalArgumentException") }
+                                + " - an instance of java.lang.IllegalArgumentException") },
+                {EvaluateNullPostCheck.class, everyTestRunSuccessful()},
+                {PassPostThrowCheck.class, everyTestRunSuccessful()},
+                {FailPostThrowCheck.class, hasSingleFailure()}
         });
     }
 
@@ -363,6 +367,53 @@ public class ExpectedExceptionTest {
         public void noThrow() {
             thrown.expect(IllegalArgumentException.class);
             thrown.reportMissingExceptionWithMessage(ARBITRARY_MESSAGE);
+        }
+    }
+
+    public static class EvaluateNullPostCheck {
+
+        @Rule
+        public ExpectedException thrown = ExpectedException.none();
+
+        @Test
+        public void throwAndDontCrashWithNullPostCheck() {
+            thrown.expect(IllegalArgumentException.class);
+            thrown.evaluatePostcheck(null);
+            throw new IllegalArgumentException();
+        }
+    }
+
+    public static class PassPostThrowCheck {
+
+        @Rule
+        public ExpectedException thrown = ExpectedException.none();
+
+        @Test
+        public void throwAndPassPostcheck() {
+            thrown.expect(IllegalArgumentException.class);
+            thrown.evaluatePostcheck(new Runnable() {
+                public void run() {
+                    Assert.assertTrue(true);
+                }
+            });
+            throw new IllegalArgumentException();
+        }
+    }
+
+    public static class FailPostThrowCheck {
+
+        @Rule
+        public ExpectedException thrown = ExpectedException.none();
+
+        @Test
+        public void throwAndFailPostcheck() {
+            thrown.expect(IllegalArgumentException.class);
+            thrown.evaluatePostcheck(new Runnable() {
+                public void run() {
+                    Assert.fail();
+                }
+            });
+            throw new IllegalArgumentException();
         }
     }
 }


### PR DESCRIPTION
# Problem
Hi *,

there is a known issue with JUnit testing. Sometimes there is a need for some assertions after an expected exception is thrown by tested method. To visualize the problem let's consider below snippet:

```java
class Dummy {
    
    private boolean called = false;

    public boolean hasMethodBeenCalled() {
        return called;
    }
    
    public void throwingMethod() throws Exception {
        called = false;   // Lol, we made a bug here - let's cross figers our unit test catch it
        throw new Exception();
    }
}

public class TestedTest {

    private final Dummy sut = new Dummy();

    @Rule
    public ExpectedException expectedException = ExpectedException.none();
    
    @Test
    public void shallThrowException() throws Exception {
        expectedException.expect(Exception.class);
        sut.throwingMethod();
        assertTrue(sut.hasMethodBeenCalled());  // Shoot, it did not - the test passes :c
    }
}
```

This is certainly what one could expect - test's flow never reaches the assertion as the preceding method throws an exception breaking it. We can assume that a check for `sut.hasMethodBeenCalled()` is somehow crucial and needs to be tested. In order to do so, a developer is forced to modify his test. One of the options is to use `try {} finally {}` expression:

```java
@Test
public void shallThrowException() throws Exception {
    expectedException.expect(Exception.class);
    try {
        sut.throwingMethod();
    }
    finally {
        assertTrue(sut.hasMethodBeenCalled());
    }
}
```

It works but is highly illegible resulting in a message:

```
Expected: an instance of java.lang.Exception
     but: <java.lang.AssertionError> is a java.lang.AssertionError
```
(or `Unexpected exception, expected<java.lang.Exception> but was<java.lang.AssertionError>` when using `@Test(expected = ...)` annotation instead of `ExpectedException` which is hardly readable whatsoever).

Thus, it forces to adopt longer `try {} catch {}` with `fail` call after `sut`:

```java
@Test
public void shallThrowException() {
    try {
        sut.throwingMethod();
        fail("Expected exception has not been thrown!");
    }
    catch (Exception ex) {
        assertTrue(sut.hasMethodBeenCalled());
    }
}
```

which finally works as intended. However, it means that a programmer has to implement it each time by his own and it's basically what `ExpectedException` is for.

# Solution
In these commits I provided `evaluatePostcheck` method to `ExpectedException`. The considered test will look like this now:

```java
@Test
public void shallThrowException() throws Exception {
    expectedException.expect(Exception.class);
    expectedException.evaluatePostcheck(() -> {
        assertTrue(sut.hasMethodBeenCalled());  // Java 8 lambda can be used as well
    });
    sut.throwingMethod();
}
```

`evaluatePostcheck` accepts `Runnable` interface as an argument. It is invoked after JUnit verifies thrown exception allowing developer to easily perform checks/assertions of the tested class's state despite broken flow.

Such a check is especially useful when mocks are used - often it's necessary to check whether a mock's method is called before the tested method throws. 