### PR TITLE
Fix #1248.

### DIFF
--- a/doc/faq/faq.htm
+++ b/doc/faq/faq.htm
@@ -110,7 +110,6 @@ Table of Contents
       forums?</a></li>
       <li><a href="#overview_4">Where is the JUnit documentation?</a></li>
       <li><a href="#overview_5">Where can I find articles on JUnit?</a></li>
-      <li><a href="#overview_6">What's the latest news on JUnit?</a></li>
       <li><a href="#overview_7">How is JUnit licensed?</a></li>
       <li><a href="#overview_8">What awards has JUnit won?</a></li>
     </ol>
@@ -403,16 +402,6 @@ Table of Contents
       The JUnit home page maintains a list
       of <a href="http://www.junit.org/news/article/index.htm">JUnit
       articles</a>.
-    </p>
-  </li>
-  <li>
-    <p>
-      <b><a name="overview_6">What's the latest news on JUnit?</a></b>
-    </p>
-    <p>
-      The JUnit home page publishes
-      the <a href="http://www.junit.org/news/index.htm">latest JUnit
-      news</a>.
     </p>
   </li>
   <li>


### PR DESCRIPTION
Fixed #1248. Delete dead faq link.